### PR TITLE
Fix polyfill issues for IE 11

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -7,12 +7,10 @@
 
 # Ignore uploaded files in development.
 /storage/*
-/public/assets
-.byebug_history
 
-/public/packs
 /public/packs-test
 /node_modules
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+.byebug_history

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.4.5)
       msgpack (~> 1.0)
-    brakeman (4.7.2)
+    brakeman (4.8.0)
     builder (3.2.4)
     bundler-audit (0.6.1)
       bundler (>= 1.2.0, < 3)
@@ -365,4 +365,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   2.1.1
+   2.1.4

--- a/app/javascript/packs/monitoring_report.jsx
+++ b/app/javascript/packs/monitoring_report.jsx
@@ -7,8 +7,7 @@ import { setAppConfig, setReportId } from 'monitoring_report/actions'
 import "core-js"
 import "regenerator-runtime/runtime"
 
-const target = document.currentScript
-
+const target = document.getElementById("monitoring-report")
 store.dispatch(setAppConfig({
   endpoint: window.location.origin
 }))
@@ -18,5 +17,5 @@ render(
   <Provider store={store}>
     <MonitoringReportApp />
   </Provider>,
-  document.getElementById("monitoring-report")
+  target
 )

--- a/app/javascript/packs/monitoring_report.jsx
+++ b/app/javascript/packs/monitoring_report.jsx
@@ -4,6 +4,8 @@ import { Provider } from 'react-redux'
 import MonitoringReportApp from 'monitoring_report/app'
 import store from 'monitoring_report/store'
 import { setAppConfig, setReportId } from 'monitoring_report/actions'
+import "core-js"
+import "regenerator-runtime/runtime"
 
 const target = document.currentScript
 

--- a/app/javascript/packs/monitoring_report.jsx
+++ b/app/javascript/packs/monitoring_report.jsx
@@ -4,8 +4,9 @@ import { Provider } from 'react-redux'
 import MonitoringReportApp from 'monitoring_report/app'
 import store from 'monitoring_report/store'
 import { setAppConfig, setReportId } from 'monitoring_report/actions'
-import "core-js"
-import "regenerator-runtime/runtime"
+import 'core-js'
+import 'regenerator-runtime/runtime'
+import 'whatwg-fetch'
 
 const target = document.getElementById("monitoring-report")
 store.dispatch(setAppConfig({

--- a/app/views/monitoring_reports/show.html.erb
+++ b/app/views/monitoring_reports/show.html.erb
@@ -1,2 +1,2 @@
-<div id="monitoring-report"></div>
-<%= javascript_pack_tag "monitoring_report", data: {"report-id": @monitoring_report.id.to_s} %>
+<div id="monitoring-report" data-report-id="<%= @monitoring_report.id %>"></div>
+<%= javascript_pack_tag "monitoring_report" %>

--- a/babel.config.js
+++ b/babel.config.js
@@ -33,7 +33,7 @@ module.exports = function(api) {
         {
           forceAllTransforms: true,
           useBuiltIns: 'entry',
-          corejs: 3,
+          corejs: '3.6',
           modules: false,
           exclude: ['transform-typeof-symbol']
         }

--- a/bin/prep-deploy.sh
+++ b/bin/prep-deploy.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+bundle exec rake docs:generate
+bundle exec rake assets:clobber
+env NODE_ENV=production RAILS_ENV=production bundle exec rake assets:precompile

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "showdown": "^1.9.1",
     "turbolinks": "^5.2.0",
     "uswds": "^2.3.1",
+    "whatwg-fetch": "^3.0.0",
     "xss": "^1.0.6"
   },
   "version": "0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1020,9 +1020,9 @@
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
 "@types/node@*", "@types/node@^13.5.0":
-  version "13.7.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.7.1.tgz#238eb34a66431b71d2aaddeaa7db166f25971a0d"
-  integrity sha512-Zq8gcQGmn4txQEJeiXo/KiLpon8TzAl0kmKH4zdWctPj05nWwp1ClMdAVEloqrQKfaC48PNLdgN/aVaLqUrluA==
+  version "13.7.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.7.2.tgz#50375b95b5845a34efda2ffb3a087c7becbc46c6"
+  integrity sha512-uvilvAQbdJvnSBFcKJ2td4016urcGvsiR+N4dHGU87ml8O2Vl6l+ErOi9w0kXSPiwJ1AYlIW+0pDXDWWMOiWbw==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -2761,9 +2761,9 @@ ee-first@1.1.1:
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
 electron-to-chromium@^1.3.349:
-  version "1.3.354"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.354.tgz#6c6ad9ef63654c4c022269517c5a3095cebc94db"
-  integrity sha512-24YMkNiZWOUeF6YeoscWfIGP0oMx+lJpU/miwI+lcu7plIDpyZn8Gx0lx0qTDlzGoz7hx+lpyD8QkbkX5L2Pqw==
+  version "1.3.355"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.355.tgz#ff805ed8a3d68e550a45955134e4e81adf1122ba"
+  integrity sha512-zKO/wS+2ChI/jz9WAo647xSW8t2RmgRLFdbUb/77cORkUTargO+SCj4ctTHjBn2VeNFrsLgDT7IuDVrd3F8mLQ==
 
 elem-dataset@^1.1.1:
   version "1.1.1"
@@ -5466,11 +5466,11 @@ pkg-dir@^4.1.0:
     find-up "^4.0.0"
 
 pnp-webpack-plugin@^1.5.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/pnp-webpack-plugin/-/pnp-webpack-plugin-1.6.0.tgz#d5c068013a2fdc82224ca50ed179c8fba9036a8e"
-  integrity sha512-ZcMGn/xF/fCOq+9kWMP9vVVxjIkMCja72oy3lziR7UHy0hHFZ57iVpQ71OtveVbmzeCmphBg8pxNdk/hlK99aQ==
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/pnp-webpack-plugin/-/pnp-webpack-plugin-1.6.4.tgz#c9711ac4dc48a685dabafc86f8b6dd9f8df84149"
+  integrity sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==
   dependencies:
-    ts-pnp "^1.1.2"
+    ts-pnp "^1.1.6"
 
 portfinder@^1.0.25:
   version "1.0.25"
@@ -6108,9 +6108,9 @@ postcss-value-parser@^3.0.0, postcss-value-parser@^3.2.3:
   integrity sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
 
 postcss-value-parser@^4.0.0, postcss-value-parser@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz#482282c09a42706d1fc9a069b73f44ec08391dc9"
-  integrity sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.0.3.tgz#651ff4593aa9eda8d5d0d66593a2417aeaeb325d"
+  integrity sha512-N7h4pG+Nnu5BEIzyeaaIYWs0LI5XC40OrRh5L60z0QjFsqGWcHcbkBvpe1WYpcIS9yQ8sOi/vIPt1ejQCrMVrg==
 
 postcss-values-parser@^2.0.0, postcss-values-parser@^2.0.1:
   version "2.0.1"
@@ -7531,10 +7531,10 @@ trim-newlines@^1.0.0:
   dependencies:
     glob "^7.1.2"
 
-ts-pnp@^1.1.2:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.1.5.tgz#840e0739c89fce5f3abd9037bb091dbff16d9dec"
-  integrity sha512-ti7OGMOUOzo66wLF3liskw6YQIaSsBgc4GOAlWRnIEj8htCxJUxskanMUoJOD6MDCRAXo36goXJZch+nOS0VMA==
+ts-pnp@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.1.6.tgz#389a24396d425a0d3162e96d2b4638900fdc289a"
+  integrity sha512-CrG5GqAAzMT7144Cl+UIFP7mz/iIhiy+xQ6GGcnjTezhALT02uPMRw7tgDSESgB5MsfKt55+GPWw4ir1kVtMIQ==
 
 tslib@^1.9.0:
   version "1.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7942,6 +7942,11 @@ websocket-extensions@>=0.1.1:
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
   integrity sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==
 
+whatwg-fetch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
+  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
+
 which-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"


### PR DESCRIPTION
Requires precompiling assets locally. cloud.gov hits memory limits otherwise